### PR TITLE
Handling rendering of HTTP/1.0 requests without Host

### DIFF
--- a/src/OpenTracing.Contrib.NetCore/AspNetCore/HostingEventProcessor.cs
+++ b/src/OpenTracing.Contrib.NetCore/AspNetCore/HostingEventProcessor.cs
@@ -96,16 +96,17 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
 
         private static string GetDisplayUrl(HttpRequest request)
         {
-            if(request.Host.HasValue)
+            if (request.Host.HasValue)
+            {
                 return request.GetDisplayUrl();
+            }
 
             // HTTP 1.0 requests are not required to provide a Host to be valid
             // Since this is just for display, we can provide a string that is
             // not an actual Uri with only the fields that are specified.
             // request.GetDisplayUrl(), used above, will throw an exception
             // if request.Host is null.
-            var host = request.Host.HasValue ? request.Host.Value : NoHostSpecified;
-            return $"{request.Scheme}://{host}{request.PathBase.Value}{request.Path.Value}{request.QueryString.Value}";
+            return $"{request.Scheme}://{NoHostSpecified}{request.PathBase.Value}{request.Path.Value}{request.QueryString.Value}";
         }
 
         private bool ShouldIgnore(HttpContext httpContext)

--- a/src/OpenTracing.Contrib.NetCore/AspNetCore/HostingEventProcessor.cs
+++ b/src/OpenTracing.Contrib.NetCore/AspNetCore/HostingEventProcessor.cs
@@ -14,6 +14,8 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
         private static readonly PropertyFetcher _httpRequestIn_stop_HttpContextFetcher = new PropertyFetcher("HttpContext");
         private static readonly PropertyFetcher _unhandledException_ExceptionFetcher = new PropertyFetcher("exception");
 
+        internal static readonly string NoHostSpecified = String.Empty;
+
         private readonly ITracer _tracer;
         private readonly ILogger _logger;
         private readonly HostingOptions _options;
@@ -55,7 +57,7 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
                                 .WithTag(Tags.Component, _options.ComponentName)
                                 .WithTag(Tags.SpanKind, Tags.SpanKindServer)
                                 .WithTag(Tags.HttpMethod, request.Method)
-                                .WithTag(Tags.HttpUrl, request.GetDisplayUrl())
+                                .WithTag(Tags.HttpUrl, GetDisplayUrl(request))
                                 .StartActive();
 
                             _options.OnRequest?.Invoke(scope.Span, httpContext);
@@ -90,6 +92,20 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
 
                 default: return false;
             }
+        }
+
+        private static string GetDisplayUrl(HttpRequest request)
+        {
+            if(request.Host.HasValue)
+                return request.GetDisplayUrl();
+
+            // HTTP 1.0 requests are not required to provide a Host to be valid
+            // Since this is just for display, we can provide a string that is
+            // not an actual Uri with only the fields that are specified.
+            // request.GetDisplayUrl(), used above, will throw an exception
+            // if request.Host is null.
+            var host = request.Host.HasValue ? request.Host.Value : NoHostSpecified;
+            return $"{request.Scheme}://{host}{request.PathBase.Value}{request.Path.Value}{request.QueryString.Value}";
         }
 
         private bool ShouldIgnore(HttpContext httpContext)

--- a/test/OpenTracing.Contrib.NetCore.Tests/AspNetCore/HostingTest1_0.cs
+++ b/test/OpenTracing.Contrib.NetCore.Tests/AspNetCore/HostingTest1_0.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting.Internal;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using OpenTracing.Contrib.NetCore.AspNetCore;
+using OpenTracing.Contrib.NetCore.Configuration;
+using OpenTracing.Contrib.NetCore.Internal;
+using OpenTracing.Mock;
+using OpenTracing.Tag;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OpenTracing.Contrib.NetCore.Tests.AspNetCore
+{
+    [Collection("DiagnosticSource") /* All DiagnosticSource tests must be in the same collection to ensure they are NOT run in parallel. */]
+    public class HostingTest1_0 : IDisposable
+    {
+        private readonly MockTracer _tracer;
+
+        private readonly IServiceProvider _serviceProvider;
+        private readonly FeatureCollection _features;
+        private readonly DiagnosticManager _diagnosticManager;
+        private readonly HostingApplication _hostingApplication;
+        private readonly DefaultHttpContext _httpContext;
+
+        public HostingTest1_0(ITestOutputHelper output)
+        {
+            _tracer = new MockTracer();
+
+            var aspNetCoreOptions = new AspNetCoreDiagnosticOptions();
+
+            _serviceProvider = new ServiceCollection()
+                .AddLogging(logging =>
+                {
+                    logging.AddXunit(output);
+                    logging.AddFilter("OpenTracing", LogLevel.Trace);
+                })
+                .AddOpenTracingCoreServices(builder =>
+                {
+                    builder.AddAspNetCore();
+
+                    builder.Services.AddSingleton<ITracer>(_tracer);
+                    builder.Services.AddSingleton(Options.Create(aspNetCoreOptions));
+                })
+                .BuildServiceProvider();
+
+            _diagnosticManager = _serviceProvider.GetRequiredService<DiagnosticManager>();
+            _diagnosticManager.Start();
+
+            // Request
+
+            _httpContext = new DefaultHttpContext();
+            SetRequest();
+
+            // Hosting Application
+
+            var diagnosticSource = new DiagnosticListener("Microsoft.AspNetCore");
+
+            _features = new FeatureCollection();
+            _features.Set<IHttpRequestFeature>(new HttpRequestFeature());
+
+            var httpContextFactory = Substitute.For<IHttpContextFactory>();
+            httpContextFactory.Create(_features).Returns(_httpContext);
+
+            _hostingApplication = new HostingApplication(
+                ctx => Task.FromResult(0),
+                _serviceProvider.GetRequiredService<ILogger<HostingTest>>(),
+                diagnosticSource,
+                httpContextFactory);
+        }
+
+        public void Dispose()
+        {
+            _diagnosticManager.Dispose();
+            (_serviceProvider as IDisposable).Dispose();
+        }
+
+        private void SetRequest()
+        {
+            var request = _httpContext.Request;
+
+            Uri requestUri = new Uri("http://www.example.com/foo");
+
+            request.Protocol = "HTTP/1.0";
+            request.Method = HttpMethods.Get;
+            request.Scheme = requestUri.Scheme;
+            // HTTP/1.0 requests are not required to provide a Host in the request
+            request.Host = new HostString();
+            if (requestUri.IsDefaultPort)
+            {
+                request.Host = new HostString(request.Host.Host);
+            }
+            request.PathBase = PathString.Empty;
+            request.Path = PathString.FromUriComponent(requestUri);
+            request.QueryString = QueryString.FromUriComponent(requestUri);
+        }
+
+        private async Task ExecuteRequestAsync(Exception exception = null)
+        {
+            var context = _hostingApplication.CreateContext(_features);
+            await _hostingApplication.ProcessRequestAsync(context);
+            _hostingApplication.DisposeContext(context, exception);
+        }
+
+        [Fact]
+        public async Task Span_has_correct_properties()
+        {
+            await ExecuteRequestAsync();
+
+            var finishedSpans = _tracer.FinishedSpans();
+            Assert.Single(finishedSpans);
+
+            var span = finishedSpans[0];
+            Assert.Empty(span.GeneratedErrors);
+            Assert.Empty(span.LogEntries);
+            Assert.Equal("HTTP GET", span.OperationName);
+            Assert.Null(span.ParentId);
+            Assert.Empty(span.References);
+
+            Assert.Equal(5, span.Tags.Count);
+            Assert.Equal(Tags.SpanKindServer, span.Tags[Tags.SpanKind.Key]);
+            Assert.Equal("HttpIn", span.Tags[Tags.Component.Key]);
+            Assert.Equal("GET", span.Tags[Tags.HttpMethod.Key]);
+            Assert.Equal($"http://{HostingEventProcessor.NoHostSpecified}/foo", span.Tags[Tags.HttpUrl.Key]);
+            Assert.Equal(200, span.Tags[Tags.HttpStatus.Key]);
+        }
+    }
+}


### PR DESCRIPTION
It is not necessary for an HTTP/1.0 request to have a host specified but `request.GetDisplayUrl()` will throw if it is null (internally, there is a call to `request.Host.Value.Length` and `request.Host.Value` will be null if it isn't in the traced request).

Rendering the Uri as `http:///foo`, where the host would normally be before the last `/`, matches logging:
`OpenTracing.Contrib.NetCore.Tests.AspNetCore.HostingTest Information: Request starting HTTP/1.0 GET http:///foo`