### PR TITLE
Add ignore patterns support for MVC event processor.

### DIFF
--- a/src/OpenTracing.Contrib.NetCore/AspNetCore/AspNetCoreDiagnostics.cs
+++ b/src/OpenTracing.Contrib.NetCore/AspNetCore/AspNetCoreDiagnostics.cs
@@ -29,7 +29,7 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
                 throw new ArgumentNullException(nameof(options));
 
             _hostingEventProcessor = new HostingEventProcessor(Tracer, Logger, options.Value.Hosting);
-            _mvcEventProcessor = new MvcEventProcessor(Tracer, Logger);
+            _mvcEventProcessor = new MvcEventProcessor(Tracer, Logger, options.Value.Hosting.IgnorePatterns);
         }
 
         protected override bool IsEnabled(string eventName)

--- a/src/OpenTracing.Contrib.NetCore/AspNetCore/MvcEventProcessor.cs
+++ b/src/OpenTracing.Contrib.NetCore/AspNetCore/MvcEventProcessor.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Extensions.Logging;
@@ -16,14 +20,20 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
         private const string ResultComponent = "AspNetCore.MvcResult";
         private const string ResultTagType = "result.type";
 
+        private static readonly PropertyFetcher _beforeActionResult_actionContextFetcher = new PropertyFetcher("actionContext");
+        
+        private static readonly PropertyFetcher _beforeAction_httpContextFetcher = new PropertyFetcher("httpContext");
+
         private static readonly PropertyFetcher _beforeAction_ActionDescriptorFetcher = new PropertyFetcher("actionDescriptor");
         private static readonly PropertyFetcher _beforeActionResult_ResultFetcher = new PropertyFetcher("result");
 
         private readonly ITracer _tracer;
         private readonly ILogger _logger;
+        private readonly IList<Func<HttpContext, bool>> _ignorePatterns;
 
-        public MvcEventProcessor(ITracer tracer, ILogger logger)
+        public MvcEventProcessor(ITracer tracer, ILogger logger, IList<Func<HttpContext, bool>> ignorePatterns)
         {
+            _ignorePatterns = ignorePatterns;
             _tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
@@ -33,6 +43,14 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
             switch (eventName)
             {
                 case "Microsoft.AspNetCore.Mvc.BeforeAction":
+                {
+                    var httpContext = (HttpContext)_beforeAction_httpContextFetcher.Fetch(arg);
+
+                    if (ShouldIgnore(httpContext))
+                    {
+                        _logger.LogDebug("Ignoring request");
+                    }
+                    else
                     {
                         // NOTE: This event is the start of the action pipeline. The action has been selected, the route
                         //       has been selected but no filters have run and model binding hasn't occured.
@@ -50,6 +68,7 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
                             .WithTag(ActionTagActionName, controllerActionDescriptor?.ActionName)
                             .StartActive();
                     }
+                }
                     return true;
 
                 case "Microsoft.AspNetCore.Mvc.AfterAction":
@@ -59,6 +78,14 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
                     return true;
 
                 case "Microsoft.AspNetCore.Mvc.BeforeActionResult":
+                {
+                    var httpContext = ((ActionContext) _beforeActionResult_actionContextFetcher.Fetch(arg)).HttpContext;
+
+                    if (ShouldIgnore(httpContext))
+                    {
+                        _logger.LogDebug("Ignoring request");
+                    }
+                    else
                     {
                         // NOTE: This event is the start of the result pipeline. The action has been executed, but
                         //       we haven't yet determined which view (if any) will handle the request
@@ -73,6 +100,7 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
                             .WithTag(ResultTagType, resultType)
                             .StartActive();
                     }
+                }
                     return true;
 
                 case "Microsoft.AspNetCore.Mvc.AfterActionResult":
@@ -83,6 +111,11 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
 
                 default: return false;
             }
+        }
+        
+        private bool ShouldIgnore(HttpContext httpContext)
+        {
+            return _ignorePatterns.Any(ignore => ignore(httpContext));
         }
     }
 }

--- a/src/OpenTracing.Contrib.NetCore/AspNetCore/MvcEventProcessor.cs
+++ b/src/OpenTracing.Contrib.NetCore/AspNetCore/MvcEventProcessor.cs
@@ -20,11 +20,9 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
         private const string ResultComponent = "AspNetCore.MvcResult";
         private const string ResultTagType = "result.type";
 
-        private static readonly PropertyFetcher _beforeActionResult_actionContextFetcher = new PropertyFetcher("actionContext");
-        
         private static readonly PropertyFetcher _beforeAction_httpContextFetcher = new PropertyFetcher("httpContext");
-
         private static readonly PropertyFetcher _beforeAction_ActionDescriptorFetcher = new PropertyFetcher("actionDescriptor");
+        private static readonly PropertyFetcher _beforeActionResult_actionContextFetcher = new PropertyFetcher("actionContext");
         private static readonly PropertyFetcher _beforeActionResult_ResultFetcher = new PropertyFetcher("result");
 
         private readonly ITracer _tracer;


### PR DESCRIPTION
There is an opportunity to [ignore some tracing patterns](https://github.com/opentracing-contrib/csharp-netcore/issues/28).  

```
            services.AddJaeger().AddOpenTracing(builder =>
                builder.ConfigureAspNetCore(options =>
                {
                    // ignore certain requests to prevent spamming the tracer with irrelevant data
                    options.Hosting.IgnorePatterns.Add(request =>
                        request.Request.Path.Value?.StartsWith("/monitoring") == true);
                }));
```
However, it doesn't work as it supposed to.

After adding such piece of code, I would expect the library to ignore all endpoints which start with `/monitoring`. 
Basically, my case is that I have `MonitoringController` with 2 endpoints - `/monitoring/health` and `/monitoring/readiness`. Container orchestrator queries these endpoints quite frequently to know the state of the service.
The code of the endpoint used in testing:
```
        [HttpGet]
        [Route("health")]
        public IActionResult Health()
        {
            var state = StateManager.CurrentState;
            if (state == State.RequiresRestart)
            {
                this.log.Warning("Health probe was requested, but service is in {State} state", state);
                return this.StatusCode(503);
            }

            return this.Ok();
        }

```
OpenTracing library records span for each and every request done which results in having irrelevant data in the Jaeger UI (a tool we use to display spans). 
So I dug into the sources to figure out what was the problem.
Expected behavior:
Not having any spans recorded and reported for requests with path `/monitoring*`.
Actual behavior:
 
![image](https://user-images.githubusercontent.com/11834902/50726684-4d491300-1119-11e9-993d-385e5054d27a.png)

Expected behavior implemented in this PR:
![image](https://user-images.githubusercontent.com/11834902/50726707-a7e26f00-1119-11e9-889c-b058f4f5f97e.png)

Also, if I add a test like that
```
        [Fact]
        public async Task Ignores_requests_with_request_path_ignore_rule()
        {
            _options.IgnorePatterns.Add(context => context.Request.Path.StartsWithSegments("/foo"));

            await ExecuteRequestAsync();

            Assert.Empty(_tracer.FinishedSpans());
        }
```
I get a classic false-positive. Let me know if this improvement makes sense. If so, would be very happy to receive any advice about the tests I should write to support this functionality.
