### PR TITLE
Add Support for SqlClientDiagnostic

### DIFF
--- a/src/OpenTracing.Contrib.NetCore/Configuration/OpenTracingBuilderExtensions.cs
+++ b/src/OpenTracing.Contrib.NetCore/Configuration/OpenTracingBuilderExtensions.cs
@@ -63,6 +63,9 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.AddDiagnosticSubscriber<HttpHandlerDiagnostics>();
             builder.ConfigureGenericDiagnostics(options => options.IgnoredListenerNames.Add(HttpHandlerDiagnostics.DiagnosticListenerName));
 
+            builder.AddDiagnosticSubscriber<SqlClientDiagnostics>();
+            builder.ConfigureGenericDiagnostics(options => options.IgnoredListenerNames.Add(SqlClientDiagnostics.DiagnosticListenerName));
+
             return builder;
         }
 

--- a/src/OpenTracing.Contrib.NetCore/CoreFx/SqlClientDiagnosticOptions.cs
+++ b/src/OpenTracing.Contrib.NetCore/CoreFx/SqlClientDiagnosticOptions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Data.SqlClient;
+using System.Linq;
+
+namespace OpenTracing.Contrib.NetCore.CoreFx
+{
+    public class SqlClientDiagnosticOptions
+    {
+        public const string DefaultComponent = "SqlClient";
+        public const string SqlClientPrefix = "sqlClient ";
+
+        private string _componentName = DefaultComponent;
+        private Func<SqlCommand, string> _operationNameResolver;
+
+        /// <summary>
+        /// Allows changing the "component" tag of created spans.
+        /// </summary>
+        public string ComponentName
+        {
+            get => _componentName;
+            set => _componentName = value ?? throw new ArgumentNullException(nameof(ComponentName));
+        }
+
+        /// <summary>
+        /// A delegate that returns the OpenTracing "operation name" for the given command.
+        /// </summary>
+        public Func<SqlCommand, string> OperationNameResolver
+        {
+            get
+            {
+                if (_operationNameResolver == null)
+                {
+                    // Default value may not be set in the constructor because this would fail
+                    // if the target application does not reference SqlClient.
+                    _operationNameResolver = (cmd) =>
+                    {
+                        var commandType = cmd.CommandText?.Split(' ');
+                        return $"{SqlClientPrefix}{commandType?.FirstOrDefault()}";
+                    };
+                }
+                return _operationNameResolver;
+            }
+            set => _operationNameResolver = value ?? throw new ArgumentNullException(nameof(OperationNameResolver));
+        }
+    }
+}

--- a/src/OpenTracing.Contrib.NetCore/CoreFx/SqlClientDiagnostics.cs
+++ b/src/OpenTracing.Contrib.NetCore/CoreFx/SqlClientDiagnostics.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpenTracing.Contrib.NetCore.Internal;
+using OpenTracing.Tag;
+
+namespace OpenTracing.Contrib.NetCore.CoreFx
+{
+    internal sealed class SqlClientDiagnostics : DiagnosticListenerObserver
+    {
+        public const string DiagnosticListenerName = "SqlClientDiagnosticListener";
+
+        private static readonly PropertyFetcher _activityCommand_RequestFetcher = new PropertyFetcher("Command");
+        private static readonly PropertyFetcher _exception_ExceptionFetcher = new PropertyFetcher("Exception");
+
+        private readonly SqlClientDiagnosticOptions _options;
+
+        public SqlClientDiagnostics(ILoggerFactory loggerFactory, ITracer tracer, IOptions<SqlClientDiagnosticOptions> options)
+           : base(loggerFactory, tracer)
+        {
+            _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        protected override string GetListenerName() => DiagnosticListenerName;
+
+        protected override void OnNext(string eventName, object untypedArg)
+        {
+            switch (eventName)
+            {
+                case "System.Data.SqlClient.WriteCommandBefore":
+                    {
+                        var args = (SqlCommand)_activityCommand_RequestFetcher.Fetch(untypedArg);
+
+                        string operationName = _options.OperationNameResolver(args);
+
+                        Tracer.BuildSpan(operationName)
+                            .WithTag(Tags.SpanKind, Tags.SpanKindClient)
+                            .WithTag(Tags.Component, _options.ComponentName)
+                            .WithTag(Tags.DbInstance, args.Connection.Database)
+                            .WithTag(Tags.DbStatement, args.CommandText)
+                            .StartActive();
+                    }
+                    break;
+
+                case "System.Data.SqlClient.WriteCommandError":
+                    {
+                        Exception ex = (Exception)_exception_ExceptionFetcher.Fetch(untypedArg);
+
+                        DisposeActiveScope(isScopeRequired: true, exception: ex);
+                    }
+                    break;
+
+                case "System.Data.SqlClient.WriteCommandAfter":
+                    {
+                        DisposeActiveScope(isScopeRequired: true);
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/src/OpenTracing.Contrib.NetCore/OpenTracing.Contrib.NetCore.csproj
+++ b/src/OpenTracing.Contrib.NetCore/OpenTracing.Contrib.NetCore.csproj
@@ -14,6 +14,7 @@ Instrumented components: HttpClient calls, ASP.NET Core, Entity Framework Core a
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
     <PackageReference Include="OpenTracing" Version="0.12.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Current time,  `SqlClientDiagnosticListener` can not get detail data when we use raw ado.net or dapper orm.

To show the `CommandText` may be more better here.

![before](https://user-images.githubusercontent.com/8394988/54170462-c23a1f80-44b1-11e9-89f4-1fd7df84059f.png)

![after](https://user-images.githubusercontent.com/8394988/54170476-d4b45900-44b1-11e9-9efb-b7ca3b65f867.png)

