### PR TITLE
Remove the current Span from the HttpRequestMessage properties on System.Net.Http.HttpRequestOut.Stop

### DIFF
--- a/src/OpenTracing.Contrib.NetCore/CoreFx/HttpHandlerDiagnostics.cs
+++ b/src/OpenTracing.Contrib.NetCore/CoreFx/HttpHandlerDiagnostics.cs
@@ -112,7 +112,7 @@ namespace OpenTracing.Contrib.NetCore.CoreFx
 
                             span.Finish();
 
-                            request.Properties[PropertiesKey] = null;
+                            request.Properties.Remove(PropertiesKey);
                         }
                     }
                     break;


### PR DESCRIPTION
On System.Net.Http.HttpRequestOut.Stop, remove the current Span from the request's Properties as opposed to setting to null.

The call to request.Properties.Add in the System.Net.Http.HttpRequestOut.Start case was throwing a key already exists exception if an http request fails AND that request had some automatic retries enabled (using Polly). 

I believe this should address issue https://github.com/opentracing-contrib/csharp-netcore/issues/51