### PR TITLE
"IgnorePatterns" for SqlClient & EF Core

### DIFF
--- a/samples/netcoreapp2.1/CustomersApi/Program.cs
+++ b/samples/netcoreapp2.1/CustomersApi/Program.cs
@@ -23,7 +23,16 @@ namespace Samples.CustomersApi
                     services.AddJaeger();
 
                     // Enables OpenTracing instrumentation for ASP.NET Core, CoreFx, EF Core
-                    services.AddOpenTracing();
+                    services.AddOpenTracing(builder =>
+                    {
+                        builder.ConfigureEntityFrameworkCore(options =>
+                        {
+                            // This is an example for how certain EF Core commands can be ignored.
+                            // As en example, we're ignoring the "PRAGMA foreign_keys=ON;" commands that are executed by Sqlite.
+                            // Remove this code to see those statements.
+                            options.IgnorePatterns.Add(cmd => cmd.Command.CommandText.StartsWith("PRAGMA"));
+                        });
+                    });
                 });
         }
     }

--- a/samples/netcoreapp3.1/CustomersApi/Program.cs
+++ b/samples/netcoreapp3.1/CustomersApi/Program.cs
@@ -27,7 +27,17 @@ namespace Samples.CustomersApi
                     services.AddJaeger();
 
                     // Enables OpenTracing instrumentation for ASP.NET Core, CoreFx, EF Core
-                    services.AddOpenTracing();
+                    services.AddOpenTracing(builder =>
+                    {
+                        builder.ConfigureEntityFrameworkCore(options =>
+                        {
+                            // This is an example for how certain EF Core commands can be ignored.
+                            // As en example, we're ignoring the "PRAGMA foreign_keys=ON;" commands that are executed by Sqlite.
+                            // Remove this code to see those statements.
+                            options.IgnorePatterns.Add(cmd => cmd.Command.CommandText.StartsWith("PRAGMA"));
+                        });
+                    });
+
                 });
         }
     }

--- a/src/OpenTracing.Contrib.NetCore/Configuration/OpenTracingBuilderExtensions.cs
+++ b/src/OpenTracing.Contrib.NetCore/Configuration/OpenTracingBuilderExtensions.cs
@@ -26,15 +26,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds instrumentation for ASP.NET Core.
         /// </summary>
-        public static IOpenTracingBuilder AddAspNetCore(this IOpenTracingBuilder builder)
+        public static IOpenTracingBuilder AddAspNetCore(this IOpenTracingBuilder builder, Action<AspNetCoreDiagnosticOptions> options = null)
         {
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));
 
             builder.AddDiagnosticSubscriber<AspNetCoreDiagnostics>();
-            builder.ConfigureGenericDiagnostics(options => options.IgnoredListenerNames.Add(AspNetCoreDiagnostics.DiagnosticListenerName));
+            builder.ConfigureGenericDiagnostics(genericOptions => genericOptions.IgnoredListenerNames.Add(AspNetCoreDiagnostics.DiagnosticListenerName));
 
-            return builder;
+            return ConfigureAspNetCore(builder, options);
         }
 
         public static IOpenTracingBuilder ConfigureAspNetCore(this IOpenTracingBuilder builder, Action<AspNetCoreDiagnosticOptions> options)
@@ -95,18 +95,31 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder;
         }
 
+        public static IOpenTracingBuilder ConfigureSqlClientDiagnostics(this IOpenTracingBuilder builder, Action<SqlClientDiagnosticOptions> options)
+        {
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
+
+            if (options != null)
+            {
+                builder.Services.Configure(options);
+            }
+
+            return builder;
+        }
+
         /// <summary>
         /// Adds instrumentation for Entity Framework Core.
         /// </summary>
-        public static IOpenTracingBuilder AddEntityFrameworkCore(this IOpenTracingBuilder builder)
+        public static IOpenTracingBuilder AddEntityFrameworkCore(this IOpenTracingBuilder builder, Action<EntityFrameworkCoreDiagnosticOptions> options = null)
         {
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));
 
             builder.AddDiagnosticSubscriber<EntityFrameworkCoreDiagnostics>();
-            builder.ConfigureGenericDiagnostics(options => options.IgnoredListenerNames.Add(EntityFrameworkCoreDiagnostics.DiagnosticListenerName));
+            builder.ConfigureGenericDiagnostics(genericOptions => genericOptions.IgnoredListenerNames.Add(EntityFrameworkCoreDiagnostics.DiagnosticListenerName));
 
-            return builder;
+            return ConfigureEntityFrameworkCore(builder, options);
         }
 
         /// <summary>

--- a/src/OpenTracing.Contrib.NetCore/CoreFx/SqlClientDiagnosticOptions.cs
+++ b/src/OpenTracing.Contrib.NetCore/CoreFx/SqlClientDiagnosticOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 
@@ -11,6 +12,13 @@ namespace OpenTracing.Contrib.NetCore.CoreFx
 
         private string _componentName = DefaultComponent;
         private Func<SqlCommand, string> _operationNameResolver;
+
+        /// <summary>
+        /// A list of delegates that define whether or not a given SQL command should be ignored.
+        /// <para/>
+        /// If any delegate in the list returns <c>true</c>, the SQL command will be ignored.
+        /// </summary>
+        public List<Func<SqlCommand, bool>> IgnorePatterns { get; } = new List<Func<SqlCommand, bool>>();
 
         /// <summary>
         /// Allows changing the "component" tag of created spans.

--- a/src/OpenTracing.Contrib.NetCore/EntityFrameworkCore/EntityFrameworkCoreDiagnosticOptions.cs
+++ b/src/OpenTracing.Contrib.NetCore/EntityFrameworkCore/EntityFrameworkCoreDiagnosticOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace OpenTracing.Contrib.NetCore.EntityFrameworkCore
@@ -9,6 +10,13 @@ namespace OpenTracing.Contrib.NetCore.EntityFrameworkCore
 
         private string _componentName = DefaultComponent;
         private Func<CommandEventData, string> _operationNameResolver;
+
+        /// <summary>
+        /// A list of delegates that define whether or not a given EF Core command should be ignored.
+        /// <para/>
+        /// If any delegate in the list returns <c>true</c>, the EF Core command will be ignored.
+        /// </summary>
+        public List<Func<CommandEventData, bool>> IgnorePatterns { get; } = new List<Func<CommandEventData, bool>>();
 
         /// <summary>
         /// Allows changing the "component" tag of created spans.


### PR DESCRIPTION
There's already #66 to solve #65, but it introduces new wording. Since we already have the "IgnorePatterns" logic in the "HttpHandlerDiagnosticOptions" class, I've added the same logic to SqlClient and EF Core.

Haven't had a chance to test the SqlClient-logic yet though since EF Core no longer uses it under the hoods.