### PR TITLE
Support for new Microsoft.Data.SqlClient

### DIFF
--- a/src/OpenTracing.Contrib.NetCore/CoreFx/SqlClientDiagnostics.cs
+++ b/src/OpenTracing.Contrib.NetCore/CoreFx/SqlClientDiagnostics.cs
@@ -28,7 +28,8 @@ namespace OpenTracing.Contrib.NetCore.CoreFx
         protected override void OnNext(string eventName, object untypedArg)
         {
             switch (eventName)
-            {
+            { 
+                case "Microsoft.Data.SqlClient.WriteCommandBefore":
                 case "System.Data.SqlClient.WriteCommandBefore":
                     {
                         var args = (SqlCommand)_activityCommand_RequestFetcher.Fetch(untypedArg);
@@ -51,6 +52,7 @@ namespace OpenTracing.Contrib.NetCore.CoreFx
                     break;
 
                 case "System.Data.SqlClient.WriteCommandError":
+                case "Microsoft.Data.SqlClient.WriteCommandError":
                     {
                         Exception ex = (Exception)_exception_ExceptionFetcher.Fetch(untypedArg);
 
@@ -59,6 +61,7 @@ namespace OpenTracing.Contrib.NetCore.CoreFx
                     break;
 
                 case "System.Data.SqlClient.WriteCommandAfter":
+                case "Microsoft.Data.SqlClient.WriteCommandAfter":
                     {
                         DisposeActiveScope(isScopeRequired: false);
                     }


### PR DESCRIPTION
As Microsoft separated SqlClient to new repository and renamed namespaces, eventNames has also changed names. 

The prefix of events in DiagnosticsListener changed to `"Microsoft.Data.SqlClient."`

https://github.com/dotnet/SqlClient/blob/a536885e4e6ccf2a98a86657609b6b72003c890c/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs#L19