### PR TITLE
Support Microsoft.Data.SqlClient & don't use "StartActive" for span storage

### DIFF
--- a/benchmarks/OpenTracing.Contrib.NetCore.Benchmarks/OpenTracing.Contrib.NetCore.Benchmarks.csproj
+++ b/benchmarks/OpenTracing.Contrib.NetCore.Benchmarks/OpenTracing.Contrib.NetCore.Benchmarks.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.1.16,3)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[2.1.14,3)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[2.1.14,3)" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/net5.0/CustomersApi/Startup.cs
+++ b/samples/net5.0/CustomersApi/Startup.cs
@@ -12,7 +12,6 @@ namespace Samples.CustomersApi
         {
             // Adds a Sqlite DB to show EFCore traces.
             services
-                .AddEntityFrameworkSqlite()
                 .AddDbContext<CustomerDbContext>(options =>
                 {
                     options.UseSqlite("Data Source=DataStore/customers.db");
@@ -23,7 +22,7 @@ namespace Samples.CustomersApi
 
         public void Configure(IApplicationBuilder app)
         {
-            // Load some dummy data into the InMemory db.
+            // Load some dummy data into the db.
             BootstrapDataStore(app.ApplicationServices);
 
             app.UseDeveloperExceptionPage();
@@ -39,7 +38,7 @@ namespace Samples.CustomersApi
             });
         }
 
-        public void BootstrapDataStore(IServiceProvider serviceProvider)
+        private void BootstrapDataStore(IServiceProvider serviceProvider)
         {
             using (var scope = serviceProvider.CreateScope())
             {

--- a/samples/net5.0/OrdersApi/Controllers/HealthController.cs
+++ b/samples/net5.0/OrdersApi/Controllers/HealthController.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OrdersApi.DataStore;
+
+namespace Samples.OrdersApi.Controllers
+{
+    [Route("health")]
+    public class HealthController : Controller
+    {
+        private readonly OrdersDbContext _dbContext;
+
+        public HealthController(OrdersDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Index()
+        {
+            await _dbContext.Orders.AnyAsync();
+
+            return Ok();
+        }
+    }
+}

--- a/samples/net5.0/OrdersApi/DataStore/Order.cs
+++ b/samples/net5.0/OrdersApi/DataStore/Order.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace OrdersApi.DataStore
+{
+    public class Order
+    {
+        [Key]
+        public int OrderId { get; set; }
+        
+        public int CustomerId { get; set; }
+
+        [Required, StringLength(10)]
+        public string ItemNumber { get; set; }
+
+        [Required, Range(1, 100)]
+        public int Quantity { get; set; }
+    }
+}

--- a/samples/net5.0/OrdersApi/DataStore/OrdersDbContext.cs
+++ b/samples/net5.0/OrdersApi/DataStore/OrdersDbContext.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace OrdersApi.DataStore
+{
+    public class OrdersDbContext : DbContext
+    {
+        public OrdersDbContext(DbContextOptions<OrdersDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Order> Orders { get; set; }
+
+        public void Seed()
+        {
+            if (Database.EnsureCreated())
+            {
+                Database.Migrate();
+
+                SaveChanges();
+            }
+        }
+    }
+}

--- a/samples/net5.0/OrdersApi/OrdersApi.csproj
+++ b/samples/net5.0/OrdersApi/OrdersApi.csproj
@@ -9,4 +9,8 @@
     <ProjectReference Include="..\..\..\src\OpenTracing.Contrib.NetCore\OpenTracing.Contrib.NetCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/samples/net5.0/OrdersApi/Startup.cs
+++ b/samples/net5.0/OrdersApi/Startup.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using OrdersApi.DataStore;
 
 namespace Samples.OrdersApi
 {
@@ -8,6 +11,13 @@ namespace Samples.OrdersApi
     {
         public void ConfigureServices(IServiceCollection services)
         {
+            // Adds a SqlServer DB to show EFCore traces.
+            services
+                .AddDbContext<OrdersDbContext>(options =>
+                {
+                    options.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=Orders-net5;Trusted_Connection=True;MultipleActiveResultSets=true");
+                });
+
             services.AddSingleton<HttpClient>();
 
             services.AddMvc();
@@ -15,6 +25,9 @@ namespace Samples.OrdersApi
 
         public void Configure(IApplicationBuilder app)
         {
+            // Load some dummy data into the db.
+            BootstrapDataStore(app.ApplicationServices);
+
             app.UseDeveloperExceptionPage();
 
             app.UseRouting();
@@ -26,6 +39,15 @@ namespace Samples.OrdersApi
             {
                 endpoints.MapDefaultControllerRoute();
             });
+        }
+
+        private void BootstrapDataStore(IServiceProvider serviceProvider)
+        {
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var dbContext = scope.ServiceProvider.GetRequiredService<OrdersDbContext>();
+                dbContext.Seed();
+            }
         }
     }
 }

--- a/samples/netcoreapp2.1/CustomersApi/CustomersApi.csproj
+++ b/samples/netcoreapp2.1/CustomersApi/CustomersApi.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.1.16,2.2)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[2.1.14,2.2)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[2.1.14,2.2)" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/netcoreapp2.1/FrontendWeb/FrontendWeb.csproj
+++ b/samples/netcoreapp2.1/FrontendWeb/FrontendWeb.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.1.16,2.2)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[2.1.14,2.2)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[2.1.14,2.2)" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/netcoreapp2.1/OrdersApi/Controllers/HealthController.cs
+++ b/samples/netcoreapp2.1/OrdersApi/Controllers/HealthController.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OrdersApi.DataStore;
+
+namespace Samples.OrdersApi.Controllers
+{
+    [Route("health")]
+    public class HealthController : Controller
+    {
+        private readonly OrdersDbContext _dbContext;
+
+        public HealthController(OrdersDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Index()
+        {
+            await _dbContext.Orders.AnyAsync();
+
+            return Ok();
+        }
+    }
+}

--- a/samples/netcoreapp2.1/OrdersApi/DataStore/Order.cs
+++ b/samples/netcoreapp2.1/OrdersApi/DataStore/Order.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace OrdersApi.DataStore
+{
+    public class Order
+    {
+        [Key]
+        public int OrderId { get; set; }
+        
+        public int CustomerId { get; set; }
+
+        [Required, StringLength(10)]
+        public string ItemNumber { get; set; }
+
+        [Required, Range(1, 100)]
+        public int Quantity { get; set; }
+    }
+}

--- a/samples/netcoreapp2.1/OrdersApi/DataStore/OrdersDbContext.cs
+++ b/samples/netcoreapp2.1/OrdersApi/DataStore/OrdersDbContext.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace OrdersApi.DataStore
+{
+    public class OrdersDbContext : DbContext
+    {
+        public OrdersDbContext(DbContextOptions<OrdersDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Order> Orders { get; set; }
+
+        public void Seed()
+        {
+            if (Database.EnsureCreated())
+            {
+                Database.Migrate();
+
+                SaveChanges();
+            }
+        }
+    }
+}

--- a/samples/netcoreapp2.1/OrdersApi/OrdersApi.csproj
+++ b/samples/netcoreapp2.1/OrdersApi/OrdersApi.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.1.16,2.2)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[2.1.14,2.2)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[2.1.14,2.2)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[2.1.14,2.2)" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/netcoreapp2.1/OrdersApi/Startup.cs
+++ b/samples/netcoreapp2.1/OrdersApi/Startup.cs
@@ -1,6 +1,8 @@
 using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using OrdersApi.DataStore;
 
 namespace Samples.OrdersApi
 {
@@ -8,6 +10,13 @@ namespace Samples.OrdersApi
     {
         public void ConfigureServices(IServiceCollection services)
         {
+            // Adds a SqlServer DB to show EFCore traces.
+            services
+                .AddDbContext<OrdersDbContext>(options =>
+                {
+                    options.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=Orders-net5;Trusted_Connection=True;MultipleActiveResultSets=true");
+                });
+
             services.AddSingleton<HttpClient>();
 
             services.AddMvc();

--- a/samples/netcoreapp2.1/OrdersApi/Startup.cs
+++ b/samples/netcoreapp2.1/OrdersApi/Startup.cs
@@ -14,7 +14,7 @@ namespace Samples.OrdersApi
             services
                 .AddDbContext<OrdersDbContext>(options =>
                 {
-                    options.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=Orders-net5;Trusted_Connection=True;MultipleActiveResultSets=true");
+                    options.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=Orders-netcoreapp21;Trusted_Connection=True;MultipleActiveResultSets=true");
                 });
 
             services.AddSingleton<HttpClient>();

--- a/samples/netcoreapp3.1/CustomersApi/CustomersApi.csproj
+++ b/samples/netcoreapp3.1/CustomersApi/CustomersApi.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[3.1.8,4)" />
   </ItemGroup>
 
 </Project>

--- a/samples/netcoreapp3.1/OrdersApi/Controllers/HealthController.cs
+++ b/samples/netcoreapp3.1/OrdersApi/Controllers/HealthController.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OrdersApi.DataStore;
+
+namespace Samples.OrdersApi.Controllers
+{
+    [Route("health")]
+    public class HealthController : Controller
+    {
+        private readonly OrdersDbContext _dbContext;
+
+        public HealthController(OrdersDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Index()
+        {
+            await _dbContext.Orders.AnyAsync();
+
+            return Ok();
+        }
+    }
+}

--- a/samples/netcoreapp3.1/OrdersApi/DataStore/Order.cs
+++ b/samples/netcoreapp3.1/OrdersApi/DataStore/Order.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace OrdersApi.DataStore
+{
+    public class Order
+    {
+        [Key]
+        public int OrderId { get; set; }
+        
+        public int CustomerId { get; set; }
+
+        [Required, StringLength(10)]
+        public string ItemNumber { get; set; }
+
+        [Required, Range(1, 100)]
+        public int Quantity { get; set; }
+    }
+}

--- a/samples/netcoreapp3.1/OrdersApi/DataStore/OrdersDbContext.cs
+++ b/samples/netcoreapp3.1/OrdersApi/DataStore/OrdersDbContext.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace OrdersApi.DataStore
+{
+    public class OrdersDbContext : DbContext
+    {
+        public OrdersDbContext(DbContextOptions<OrdersDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Order> Orders { get; set; }
+
+        public void Seed()
+        {
+            if (Database.EnsureCreated())
+            {
+                Database.Migrate();
+
+                SaveChanges();
+            }
+        }
+    }
+}

--- a/samples/netcoreapp3.1/OrdersApi/OrdersApi.csproj
+++ b/samples/netcoreapp3.1/OrdersApi/OrdersApi.csproj
@@ -9,4 +9,8 @@
     <ProjectReference Include="..\..\..\src\OpenTracing.Contrib.NetCore\OpenTracing.Contrib.NetCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[3.1.8,4)" />
+  </ItemGroup>
+
 </Project>

--- a/samples/netcoreapp3.1/OrdersApi/Startup.cs
+++ b/samples/netcoreapp3.1/OrdersApi/Startup.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using OrdersApi.DataStore;
 
 namespace Samples.OrdersApi
 {
@@ -8,6 +11,13 @@ namespace Samples.OrdersApi
     {
         public void ConfigureServices(IServiceCollection services)
         {
+            // Adds a SqlServer DB to show EFCore traces.
+            services
+                .AddDbContext<OrdersDbContext>(options =>
+                {
+                    options.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=Orders-net5;Trusted_Connection=True;MultipleActiveResultSets=true");
+                });
+
             services.AddSingleton<HttpClient>();
 
             services.AddMvc();
@@ -15,6 +25,9 @@ namespace Samples.OrdersApi
 
         public void Configure(IApplicationBuilder app)
         {
+            // Load some dummy data into the db.
+            BootstrapDataStore(app.ApplicationServices);
+
             app.UseDeveloperExceptionPage();
 
             app.UseRouting();
@@ -26,6 +39,15 @@ namespace Samples.OrdersApi
             {
                 endpoints.MapDefaultControllerRoute();
             });
+        }
+
+        private void BootstrapDataStore(IServiceProvider serviceProvider)
+        {
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var dbContext = scope.ServiceProvider.GetRequiredService<OrdersDbContext>();
+                dbContext.Seed();
+            }
         }
     }
 }

--- a/samples/netcoreapp3.1/OrdersApi/Startup.cs
+++ b/samples/netcoreapp3.1/OrdersApi/Startup.cs
@@ -15,7 +15,7 @@ namespace Samples.OrdersApi
             services
                 .AddDbContext<OrdersDbContext>(options =>
                 {
-                    options.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=Orders-net5;Trusted_Connection=True;MultipleActiveResultSets=true");
+                    options.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=Orders-netcoreapp31;Trusted_Connection=True;MultipleActiveResultSets=true");
                 });
 
             services.AddSingleton<HttpClient>();

--- a/src/OpenTracing.Contrib.NetCore/AspNetCore/AspNetCoreDiagnostics.cs
+++ b/src/OpenTracing.Contrib.NetCore/AspNetCore/AspNetCoreDiagnostics.cs
@@ -46,9 +46,6 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
 
         protected override void OnNext(string eventName, object untypedArg)
         {
-            if (!IsEnabled(eventName))
-                return;
-
             bool eventProcessed = _hostingEventProcessor.ProcessEvent(eventName, untypedArg)
                 || _mvcEventProcessor.ProcessEvent(eventName, untypedArg);
 

--- a/src/OpenTracing.Contrib.NetCore/AspNetCore/HostingEventProcessor.cs
+++ b/src/OpenTracing.Contrib.NetCore/AspNetCore/HostingEventProcessor.cs
@@ -15,7 +15,7 @@ namespace OpenTracing.Contrib.NetCore.AspNetCore
         private static readonly PropertyFetcher _unhandledException_HttpContextFetcher = new PropertyFetcher("httpContext");
         private static readonly PropertyFetcher _unhandledException_ExceptionFetcher = new PropertyFetcher("exception");
 
-        internal static readonly string NoHostSpecified = String.Empty;
+        internal static readonly string NoHostSpecified = string.Empty;
 
         private readonly ITracer _tracer;
         private readonly ILogger _logger;

--- a/src/OpenTracing.Contrib.NetCore/Configuration/OpenTracingBuilderExtensions.cs
+++ b/src/OpenTracing.Contrib.NetCore/Configuration/OpenTracingBuilderExtensions.cs
@@ -7,6 +7,7 @@ using OpenTracing.Contrib.NetCore.CoreFx;
 using OpenTracing.Contrib.NetCore.EntityFrameworkCore;
 using OpenTracing.Contrib.NetCore.Internal;
 using OpenTracing.Contrib.NetCore.Logging;
+using OpenTracing.Contrib.NetCore.MicrosoftSqlClient;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -105,6 +106,36 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         public static IOpenTracingBuilder ConfigureSqlClientDiagnostics(this IOpenTracingBuilder builder, Action<SqlClientDiagnosticOptions> options)
+        {
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
+
+            if (options != null)
+            {
+                builder.Services.Configure(options);
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds instrumentation for Microsoft.Data.SqlClient.
+        /// </summary>
+        public static IOpenTracingBuilder AddMicrosoftSqlClient(this IOpenTracingBuilder builder)
+        {
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
+
+            builder.AddDiagnosticSubscriber<MicrosoftSqlClientDiagnostics>();
+            builder.ConfigureGenericDiagnostics(genericOptions => genericOptions.IgnoredListenerNames.Add(MicrosoftSqlClientDiagnostics.DiagnosticListenerName));
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Configuration options for the instrumentation of Microsoft.Data.SqlClient.
+        /// </summary>
+        public static IOpenTracingBuilder ConfigureMicrosoftSqlClient(this IOpenTracingBuilder builder, Action<MicrosoftSqlClientDiagnosticOptions> options)
         {
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));

--- a/src/OpenTracing.Contrib.NetCore/Configuration/ServiceCollectionExtensions.cs
+++ b/src/OpenTracing.Contrib.NetCore/Configuration/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 otBuilder.AddCoreFx();
                 otBuilder.AddLoggerProvider();
                 otBuilder.AddEntityFrameworkCore();
+                otBuilder.AddMicrosoftSqlClient();
 
                 if (AssemblyExists("Microsoft.AspNetCore.Hosting"))
                 {

--- a/src/OpenTracing.Contrib.NetCore/Internal/DiagnosticListenerObserver.cs
+++ b/src/OpenTracing.Contrib.NetCore/Internal/DiagnosticListenerObserver.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
-using OpenTracing.Contrib.NetCore.Configuration;
 
 namespace OpenTracing.Contrib.NetCore.Internal
 {
@@ -47,7 +46,10 @@ namespace OpenTracing.Contrib.NetCore.Internal
         {
             try
             {
-                OnNext(value.Key, value.Value);
+                if (IsEnabled(value.Key))
+                {
+                    OnNext(value.Key, value.Value);
+                }
             }
             catch (Exception ex)
             {

--- a/src/OpenTracing.Contrib.NetCore/Internal/GenericEventProcessor.cs
+++ b/src/OpenTracing.Contrib.NetCore/Internal/GenericEventProcessor.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
-using OpenTracing.Contrib.NetCore.Configuration;
 using OpenTracing.Tag;
 
 namespace OpenTracing.Contrib.NetCore.Internal

--- a/src/OpenTracing.Contrib.NetCore/Internal/TracerExtensions.cs
+++ b/src/OpenTracing.Contrib.NetCore/Internal/TracerExtensions.cs
@@ -7,8 +7,7 @@ namespace OpenTracing.Contrib.NetCore.Internal
     {
         public static bool IsNoopTracer(this ITracer tracer)
         {
-            // TODO Change if https://github.com/opentracing/opentracing-csharp/pull/77 gets released.
-            if (tracer == NoopTracerFactory.Create())
+            if (tracer is NoopTracer)
                 return true;
 
             // There's no way to check the underlying tracer on the instance so we have to check the static method.

--- a/src/OpenTracing.Contrib.NetCore/MicrosoftSqlClient/MicrosoftSqlClientDiagnosticOptions.cs
+++ b/src/OpenTracing.Contrib.NetCore/MicrosoftSqlClient/MicrosoftSqlClientDiagnosticOptions.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
+using Microsoft.Data.SqlClient;
 
-namespace OpenTracing.Contrib.NetCore.CoreFx
+namespace OpenTracing.Contrib.NetCore.MicrosoftSqlClient
 {
-    public class SqlClientDiagnosticOptions
+    public class MicrosoftSqlClientDiagnosticOptions
     {
         public const string DefaultComponent = "SqlClient";
         public const string SqlClientPrefix = "sqlClient ";

--- a/src/OpenTracing.Contrib.NetCore/MicrosoftSqlClient/MicrosoftSqlClientDiagnostics.cs
+++ b/src/OpenTracing.Contrib.NetCore/MicrosoftSqlClient/MicrosoftSqlClientDiagnostics.cs
@@ -1,24 +1,24 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenTracing.Contrib.NetCore.Internal;
 using OpenTracing.Tag;
 
-namespace OpenTracing.Contrib.NetCore.CoreFx
+namespace OpenTracing.Contrib.NetCore.MicrosoftSqlClient
 {
-    internal sealed class SqlClientDiagnostics : DiagnosticListenerObserver
+    internal sealed class MicrosoftSqlClientDiagnostics : DiagnosticListenerObserver
     {
         public const string DiagnosticListenerName = "SqlClientDiagnosticListener";
 
         private static readonly PropertyFetcher _activityCommand_RequestFetcher = new PropertyFetcher("Command");
         private static readonly PropertyFetcher _exception_ExceptionFetcher = new PropertyFetcher("Exception");
 
-        private readonly SqlClientDiagnosticOptions _options;
+        private readonly MicrosoftSqlClientDiagnosticOptions _options;
         private readonly ConcurrentDictionary<object, ISpan> _spanStorage;
 
-        public SqlClientDiagnostics(ILoggerFactory loggerFactory, ITracer tracer, IOptions<SqlClientDiagnosticOptions> options,
+        public MicrosoftSqlClientDiagnostics(ILoggerFactory loggerFactory, ITracer tracer, IOptions<MicrosoftSqlClientDiagnosticOptions> options,
             IOptions<GenericEventOptions> genericEventOptions)
            : base(loggerFactory, tracer, genericEventOptions.Value)
         {
@@ -30,14 +30,14 @@ namespace OpenTracing.Contrib.NetCore.CoreFx
 
         protected override bool IsEnabled(string eventName)
         {
-            return eventName.StartsWith("System.Data.SqlClient");
+            return eventName.StartsWith("Microsoft.Data.SqlClient");
         }
 
         protected override void OnNext(string eventName, object untypedArg)
         {
             switch (eventName)
             {
-                case "System.Data.SqlClient.WriteCommandBefore":
+                case "Microsoft.Data.SqlClient.WriteCommandBefore":
                     {
                         var cmd = (SqlCommand)_activityCommand_RequestFetcher.Fetch(untypedArg);
 
@@ -60,7 +60,7 @@ namespace OpenTracing.Contrib.NetCore.CoreFx
                     }
                     break;
 
-                case "System.Data.SqlClient.WriteCommandError":
+                case "Microsoft.Data.SqlClient.WriteCommandError":
                     {
                         var cmd = (SqlCommand)_activityCommand_RequestFetcher.Fetch(untypedArg);
                         var ex = (Exception)_exception_ExceptionFetcher.Fetch(untypedArg);
@@ -73,7 +73,7 @@ namespace OpenTracing.Contrib.NetCore.CoreFx
                     }
                     break;
 
-                case "System.Data.SqlClient.WriteCommandAfter":
+                case "Microsoft.Data.SqlClient.WriteCommandAfter":
                     {
                         var cmd = (SqlCommand)_activityCommand_RequestFetcher.Fetch(untypedArg);
 

--- a/src/OpenTracing.Contrib.NetCore/OpenTracing.Contrib.NetCore.csproj
+++ b/src/OpenTracing.Contrib.NetCore/OpenTracing.Contrib.NetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
@@ -17,13 +17,14 @@ Instrumented components: HttpClient calls, ASP.NET Core, Entity Framework Core a
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[2.1.1,3)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="[2.1.1,3)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="[2.1.1,3)" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />
     <!-- Instrumented libraries (which are not visible as actual dependencies) -->
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.1.1,3)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.1.16,3)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[2.1.14,3)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[2.1.14,3)" PrivateAssets="All" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.6.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework)=='netcoreapp3.1'">
@@ -36,11 +37,12 @@ Instrumented components: HttpClient calls, ASP.NET Core, Entity Framework Core a
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3.1.8,4)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.8,4)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="[3.1.8,4)" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <!-- Instrumented libraries (which are not visible as actual dependencies) -->
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.1.8,4)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.1.8,4)" PrivateAssets="All" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework)=='net5.0'">
@@ -53,11 +55,12 @@ Instrumented components: HttpClient calls, ASP.NET Core, Entity Framework Core a
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[5.0.0,6)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="[5.0.0,6)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0,6)" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
     <!-- Instrumented libraries (which are not visible as actual dependencies) -->
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5.0.1,6)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[5.0.1,6)" PrivateAssets="All" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
 </Project>

--- a/test/OpenTracing.Contrib.NetCore.Tests/OpenTracing.Contrib.NetCore.Tests.csproj
+++ b/test/OpenTracing.Contrib.NetCore.Tests/OpenTracing.Contrib.NetCore.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.1.16,3)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[2.1.14,3)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[2.1.14,3)" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework)=='netcoreapp3.1'">


### PR DESCRIPTION
This is the successor of #77 as supporting Microsoft.Data.SqlClient requires different diagnostic listeners. It would otherwise throw casting exceptions.

This also fixes #64 by no longer making the SqlClient-spans active. This didn't work as the SqlClient-libraries use custom async handling that didn't properly work with the AsyncLocal-storage of OpenTracing. The "WriteCommandAfter" events therefore finished the wrong spans (e.g. the EF Core span instead of the SqlClientSpan).

It also adds SqlServer to the OrdersApi-samples so that the behaviour can be tested.

I'll immediately merge this as there hasn't been any other activity in the last few months and I want to get a new version out today. Feel free to comment/create issues if you see any concerns.