### PR TITLE
Removing overly restrictive version cap on Microsoft.Extensions packages

### DIFF
--- a/src/OpenTracing.Contrib.NetCore/OpenTracing.Contrib.NetCore.csproj
+++ b/src/OpenTracing.Contrib.NetCore/OpenTracing.Contrib.NetCore.csproj
@@ -13,10 +13,10 @@ Instrumented components: HttpClient calls, ASP.NET Core, Entity Framework Core a
 
   <ItemGroup Condition="$(TargetFramework)=='netcoreapp2.1'">
     <!-- Main dependencies -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[2.1.1,3)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[2.1.1,3)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[2.1.1,3)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="[2.1.1,3)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[2.1.1,7)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[2.1.1,7)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[2.1.1,7)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[2.1.1,7)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />
     <!-- Instrumented libraries (which are not visible as actual dependencies) -->
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.1.1,3)" PrivateAssets="All" />
@@ -33,10 +33,10 @@ Instrumented components: HttpClient calls, ASP.NET Core, Entity Framework Core a
 
   <ItemGroup Condition="$(TargetFramework)=='netcoreapp3.1'">
     <!-- Main dependencies -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.8,4)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3.1.8,4)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.8,4)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="[3.1.8,4)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.8,7)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3.1.8,7)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.8,7)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[3.1.8,7)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
     <!-- Instrumented libraries (which are not visible as actual dependencies) -->
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" PrivateAssets="All" />
@@ -51,10 +51,10 @@ Instrumented components: HttpClient calls, ASP.NET Core, Entity Framework Core a
 
   <ItemGroup Condition="$(TargetFramework)=='net5.0'">
     <!-- Main dependencies -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0.0,6)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[5.0.0,6)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[5.0.0,6)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0,6)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0.0,7)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[5.0.0,7)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[5.0.0,7)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0,7)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
     <!-- Instrumented libraries (which are not visible as actual dependencies) -->
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" PrivateAssets="All" />


### PR DESCRIPTION
Version 6.0.0 of the Microsoft.Extensions.** packages all support `netstandard2.0` so can be used all the way back to `netcoreapp2.1`.

This is causing issues where some apps that are still on `netcoreapp3.1` are using another package that requires Microsoft.Extensions.Logging.Console 5.0.0+ which references Microsoft.Extensions.DependencyInjection.Abstractions 5.0.0. But this package has a requirement of <4.0.0 for M.E.DI.A (despite the fact that there is nothing otherwise that would prevent 5.0.0+ from being used).

Note that this won't change the version used for any existing usages. It will only allow other use cases to opt in to reference a higher version.